### PR TITLE
Require core approval on check-review pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -60,6 +60,12 @@
       initial review to allow for secrets usage.
     manager: independent
     post-review: true
+    require:
+      github:
+        review:
+          # Require an approval from user with write access (e.g. core-reviewer)
+          - permission: write
+            type: approved
     trigger:
       github:
         # Run this pipeline on new/changed pull requests


### PR DESCRIPTION
Zuul config is confusing

Setting `post-review` just marks the pipeline so any jobs in it can use secrets.
It doesn't actually mean that the code must be reviewed before the pipeline can run.
For that, we need a `require:` tag

This change adds that requirement to the check-review pipeline