### PR TITLE
Review approval trigger for check-review pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -68,10 +68,14 @@
             type: approved
     trigger:
       github:
-        # Run this pipeline on new/changed pull requests
+        # Run this pipeline on approved pull requests
+        - event: pull_request_review
+          action: submitted
+          state:
+            - approved
+        # Run this pipeline on changed pull requests
         - event: pull_request
           action:
-            - opened
             - changed
             - reopened
         # Run in response to a pull request comment "recheck"


### PR DESCRIPTION
check-review pipeline currently only runs after approval and close/reopen of the PR. This change makes it run when the PR is reviewed and approved