### PR TITLE
Use CI flavors for tenks nodepool

### DIFF
--- a/ansible/inventory/group_vars/all/zuul-operator-nodepool
+++ b/ansible/inventory/group_vars/all/zuul-operator-nodepool
@@ -208,7 +208,7 @@ zuul_operator_nodepool_yaml:
               boot-from-volume: true
               console-log: True
               cloud-image: ubuntu-noble-tenks
-              flavor-name: general.v1.medium
+              flavor-name: ci.v1.medium
               key-name: zuul-ci
               userdata: |-
                 #cloud-config
@@ -228,7 +228,7 @@ zuul_operator_nodepool_yaml:
               boot-from-volume: true
               console-log: True
               cloud-image: rocky-9-tenks
-              flavor-name: general.v1.medium
+              flavor-name: ci.v1.medium
               key-name: zuul-ci
               userdata: |-
                 #cloud-config


### PR DESCRIPTION
Check-review jobs are failing because the seed VM on in the tenks job is too slow. Pulp api interactions time out.

17 seconds to curl the api json spec on a highmem node, 5 seconds on a gpu node

The flavor doesn't actually exist yet cause the CI on smslab-config fails, but the job fails anyway so :shrug: 