### PR TITLE
Ensure default service account gets namespaces role

### DIFF
--- a/ansible/inventory/group_vars/all/rbac
+++ b/ansible/inventory/group_vars/all/rbac
@@ -120,6 +120,9 @@ zuul_operator_rbac: |
   - kind: ServiceAccount
     name: zuul-operator
     namespace: zuul
+  - kind: ServiceAccount
+    name: default
+    namespace: zuul
   roleRef:
     kind: ClusterRole
     name: cluster-admin #zuul-operator


### PR DESCRIPTION
Error from kubernetes nodepool launcher log:
```
"Failure", "message":"namespaces is forbidden: User \"system:serviceaccount:zuul:default\" cannot list resource \"namespaces\" in API group \"\" at the cluster scope"
```